### PR TITLE
Use the recommended ua

### DIFF
--- a/static/pio.js
+++ b/static/pio.js
@@ -64,7 +64,7 @@ var Paul_Pio = function (prop) {
         // 是否为移动设备
         isMobile: function () {
             var ua = window.navigator.userAgent.toLowerCase();
-            ua = ua.indexOf("mobile") || ua.indexOf("android") || ua.indexOf("ios");
+            ua = ua.indexOf("mobi") || ua.indexOf("android") || ua.indexOf("ios");
 
             return window.innerWidth < 500 || ua !== -1;
         }


### PR DESCRIPTION
> In summary, we recommend looking for the string “Mobi” anywhere in the User Agent to detect a mobile device.

Mozilla推荐使用Mobi进行UA判定。

文档地址: https://developer.mozilla.org/en-US/docs/Web/HTTP/Browser_detection_using_the_user_agent#Mobile_Tablet_or_Desktop