### PR TITLE
SDK3/4 support

### DIFF
--- a/static/pio_sdk4.js
+++ b/static/pio_sdk4.js
@@ -130,4 +130,4 @@ let pio_alignment = "right"
 
 
 let app
-_pio_initialize()
+window.addEventListener("DOMContentLoaded", _pio_initialize)

--- a/static/pio_sdk4.js
+++ b/static/pio_sdk4.js
@@ -2,12 +2,14 @@
 
 # Pio SDK 2/3/4 support
 # By: jupiterbjy
-# Last Update: 2021.3.6
+# Last Update: 2021.3.7
 
 To use this, you need to include following sources to your HTML file first.
 Basic usage is same with Paul-Pio.
 
 Make sure to call `pio_refresh_style()` upon changing styles on either *pio-container* or *pio* canvas object.
+
+To change alignment, modify variable `pio_alignment` to either `left` or `right`, then call `pio_refresh_style()`.
 
 <script src="https://cubism.live2d.com/sdk-web/cubismcore/live2dcubismcore.min.js"></script>
 <script src="https://cdn.jsdelivr.net/gh/dylanNew/live2d/webgl/Live2D/lib/live2d.min.js"></script>
@@ -89,7 +91,7 @@ function _pio_initialize_container(){
 }
 
 
-function pio_refresh_style(alignment="right"){
+function pio_refresh_style(){
     // Had to separate this from PIXI initialization
     // or first loaded Live2D's size will break on resizing.
     //
@@ -99,7 +101,7 @@ function pio_refresh_style(alignment="right"){
     let pio_container = document.getElementsByClassName("pio-container").item(0)
 
     pio_container.classList.remove("left", "right")
-    pio_container.classList.add(alignment)
+    pio_container.classList.add(pio_alignment)
 
     app.resizeTo = document.getElementById("pio")
 }
@@ -121,6 +123,11 @@ function _pio_initialize() {
 
     pio_refresh_style()
 }
+
+// change alignment to left by modifying this value in other script.
+// Make sure to call `pio_refresh_style` to apply changes!
+let pio_alignment = "right"
+
 
 let app
 _pio_initialize()

--- a/static/pio_sdk4.js
+++ b/static/pio_sdk4.js
@@ -1,0 +1,126 @@
+/* ----
+
+# Pio SDK 2/3/4 support
+# By: jupiterbjy
+# Last Update: 2021.3.6
+
+To use this, you need to include following sources to your HTML file first.
+Basic usage is same with Paul-Pio.
+
+Make sure to call `pio_refresh_style()` upon changing styles on either *pio-container* or *pio* canvas object.
+
+<script src="https://cubism.live2d.com/sdk-web/cubismcore/live2dcubismcore.min.js"></script>
+<script src="https://cdn.jsdelivr.net/gh/dylanNew/live2d/webgl/Live2D/lib/live2d.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/pixi.js@5.3.6/dist/pixi.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/pixi-live2d-display/dist/index.min.js"></script>
+
+---- */
+
+
+function loadlive2d(canvas, json_object_or_url) {
+    // Replaces original l2d method 'loadlive2d' for Pio.
+
+    console.log("[Pio] Loading new model!")
+
+    try {
+        app.stage.removeChildAt(0)
+    } catch (error) {
+
+    }
+
+    let model = PIXI.live2d.Live2DModel.fromSync(json_object_or_url)
+
+    model.once("load", () => {
+        app.stage.addChild(model)
+
+        const canvas_ = document.getElementById("pio")
+
+        const scaleX = canvas_.width / model.width;
+        const scaleY = canvas_.height / model.height;
+
+        model.scale.set(Math.min(scaleX, scaleY));
+
+        // check alignment, and align model to corner
+        if (document.getElementsByClassName("pio-container").item(0).className.includes("left")){
+            model.x = 0
+        } else {
+            model.x = canvas_.width - model.width
+        }
+        model.y = (canvas_.height - model.height) / 2
+
+
+        // Hit callback definition
+        model.on('hit', hitAreas => {
+            if (hitAreas.includes('body')) {
+                console.log(`[Pio] Touch on body (SDK2)`)
+                model.motion('tap_body')
+
+            } else if (hitAreas.includes("Body")) {
+                console.log(`[Pio] Touch on body (SDK3/4)`)
+                model.motion('Tap')
+
+            } else if (hitAreas.includes("head") || hitAreas.includes("Head")){
+                console.log(`[Pio] Touch on head`)
+                model.expression()
+            }
+        })
+        console.log(`[Pio] New model h/w dimension: ${model.height} ${model.width}`)
+        console.log(`[Pio] New model x/y offset: ${model.x} ${model.y}`)
+    })
+}
+
+
+function _pio_initialize_container(){
+
+    // Generate structure
+    let pio_container = document.createElement("div")
+    pio_container.classList.add("pio-container")
+    document.body.insertAdjacentElement("beforeend", pio_container)
+
+    // Generate action
+    let pio_action = document.createElement("div")
+    pio_action.classList.add("pio-action")
+    pio_container.insertAdjacentElement("beforeend", pio_action)
+
+    // Generate canvas
+    let pio_canvas = document.createElement("canvas")
+    pio_canvas.id = "pio"
+    pio_container.insertAdjacentElement("beforeend", pio_canvas)
+}
+
+
+function pio_refresh_style(alignment="right"){
+    // Had to separate this from PIXI initialization
+    // or first loaded Live2D's size will break on resizing.
+    //
+    // Always make sure to call this after container/canvas style changes!
+    // You can set alignment here, but still you can change it manually.
+
+    let pio_container = document.getElementsByClassName("pio-container").item(0)
+
+    pio_container.classList.remove("left", "right")
+    pio_container.classList.add(alignment)
+
+    app.resizeTo = document.getElementById("pio")
+}
+
+
+function _pio_initialize_pixi_app() {
+
+    app = new PIXI.Application({
+        view: document.getElementById("pio"),
+        transparent: true,
+        autoStart: true,
+    })
+}
+
+
+function _pio_initialize() {
+    _pio_initialize_container()
+    _pio_initialize_pixi_app()
+
+    pio_refresh_style()
+}
+
+let app
+_pio_initialize()

--- a/static/pio_sdk4.js
+++ b/static/pio_sdk4.js
@@ -35,10 +35,12 @@ function loadlive2d(canvas, json_object_or_url) {
 
         const canvas_ = document.getElementById("pio")
 
-        const scaleX = canvas_.width / model.width;
-        const scaleY = canvas_.height / model.height;
+        const vertical_factor = canvas_.height / model.height
+        model.scale.set(vertical_factor)
 
-        model.scale.set(Math.min(scaleX, scaleY));
+        // match canvas to model width
+        canvas_.width = model.width
+        pio_refresh_style()
 
         // check alignment, and align model to corner
         if (document.getElementsByClassName("pio-container").item(0).className.includes("left")){
@@ -46,8 +48,6 @@ function loadlive2d(canvas, json_object_or_url) {
         } else {
             model.x = canvas_.width - model.width
         }
-        model.y = (canvas_.height - model.height) / 2
-
 
         // Hit callback definition
         model.on('hit', hitAreas => {


### PR DESCRIPTION
This script is dependent on [PIXI](https://cdn.jsdelivr.net/npm/pixi.js@5.3.6/dist/pixi.min.js), [pixi-live2d-display](https://github.com/guansss/pixi-live2d-display).

As a result, following lines should be added to ```html``` to start pio.
```html
<!-- Copyrighted cubism SDK -->
<script src="https://cubism.live2d.com/sdk-web/cubismcore/live2dcubismcore.min.js"></script>
<script src="https://cdn.jsdelivr.net/gh/dylanNew/live2d/webgl/Live2D/lib/live2d.min.js"></script>

<!-- PIXI -->
<script src="https://cdn.jsdelivr.net/npm/pixi.js@5.3.6/dist/pixi.min.js"></script>

<!-- pixi-live2d-display -->
<script src="https://cdn.jsdelivr.net/npm/pixi-live2d-display/dist/index.min.js"></script>

<!-- pio -->
<script src="pio.js"></script>
<script src="pio_sdk4.js"></script>
<link href="pio.css" rel='stylesheet' type='text/css'/>
```

Demo is available [here](https://jupiterbjy.github.io/PaulPio_PIXI_Demo/), files used - including this script - is shown [here](https://github.com/jupiterbjy/jupiterbjy.github.io/tree/main/docs/PaulPio_PIXI_Demo).